### PR TITLE
Add flag to Ansible to enable/disable uploading test symbols and crash dumps.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 
 ---
 
+ansible_socorro_run_tests: True
+
 socorro_working_dir: "{{ ansible_env.HOME }}/socorro"
 socorro_virtualenv_bin_dir: "{{ socorro_working_dir }}/socorro-virtualenv/bin"
 socorro_symbols_dir: "{{ ansible_env.HOME }}/socorro-symbols"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -196,6 +196,7 @@
     mode=0755
 
 - name: Upload testing symbols
+  when: ansible_socorro_run_tests
   copy:
     dest="{{ socorro_symbols_temp_dir }}/{{ item }}"
     src="{{ item }}"
@@ -203,6 +204,7 @@
     - "{{ socorro_upload_testing_symbols }}"
 
 - name: Copy testing symbols to directory
+  when: ansible_socorro_run_tests
   command: ./copy-symbol.sh {{ item }} {{ socorro_symbols_dir }}
   args:
     chdir: "{{ socorro_symbols_temp_dir }}"
@@ -255,20 +257,25 @@
   become_user: root
 
 - name: Upload testing dump
+  when: ansible_socorro_run_tests
   copy:
     dest="{{ socorro_symbols_temp_dir }}/segfault.dmp"
     src=segfault.dmp
 
 - name: Upload testing dump (remote test)
+  when: ansible_socorro_run_tests
   command: "curl -H 'Host: crash-reports' -F ProductName=Test -F Version=1.0 -F upload_file_minidump=@segfault.dmp 'http://{{ inventory_hostname }}:5000/submit'"
   args:
     chdir: "{{ socorro_symbols_temp_dir }}"
   register: x
 
 - debug: msg="{{ x.cmd }}"
+  when: ansible_socorro_run_tests
 - debug: msg="{{ x.stdout_lines }}"
+  when: ansible_socorro_run_tests
 
 - name: Upload testing dump (local test)
+  when: ansible_socorro_run_tests
   local_action: "command curl -H 'Host: crash-reports' -F ProductName=Test -F Version=1.0 -F upload_file_minidump=@segfault.dmp 'http://{{ inventory_hostname }}:5000/submit'"
   args:
     chdir: "{{ role_path }}/files"
@@ -276,6 +283,8 @@
   become: false
 
 - debug: msg="{{ x.cmd }}"
+  when: ansible_socorro_run_tests
 - debug: msg="{{ x.stdout_lines }}"
+  when: ansible_socorro_run_tests
 
 - debug: msg="Visit http://{{ inventory_hostname }}:5601 and search for 'socorro_reports'"


### PR DESCRIPTION
This would be usefull during deployment to Virtual Machines.

For virtual machines usually we cannot connect to them using `inventory_hostname` as hostname. (this is the assumption of uploading testing crash dumps script).